### PR TITLE
feat: add WithBaseDir option for custom golden file directory

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -37,7 +37,13 @@ func New(tb testing.TB, opts ...Option) *Golden {
 	// Get test file and function name
 	testFile, testFunc := getTestInfo()
 
-	mgr := manager.New("testdata", testFile, testFunc)
+	// Use custom baseDir if provided, otherwise default to "testdata"
+	baseDir := options.BaseDir
+	if baseDir == "" {
+		baseDir = "testdata"
+	}
+
+	mgr := manager.New(baseDir, testFile, testFunc)
 
 	// Create comparator with smart options
 	compOpts := comparator.Options{

--- a/golden_test.go
+++ b/golden_test.go
@@ -71,3 +71,25 @@ func TestGoldenEnvironmentVariable(t *testing.T) {
 		t.Fatalf("Golden file was not created when GOLDEN_UPDATE=true")
 	}
 }
+
+func TestGoldenWithBaseDir(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for the custom base dir
+	customDir := t.TempDir()
+
+	// Create golden file in custom directory
+	g := New(t, WithUpdate(true), WithBaseDir(customDir))
+	testData := "custom dir test content"
+	g.Assert("basedir_test", testData)
+
+	// Verify file was created in custom directory
+	expectedPath := filepath.Join(customDir, "golden_test_TestGoldenWithBaseDir_basedir_test.golden.go")
+	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
+		t.Fatalf("Golden file was not created in custom base directory: %s", expectedPath)
+	}
+
+	// Compare with existing golden file (should pass)
+	g = New(t, WithUpdate(false), WithBaseDir(customDir))
+	g.Assert("basedir_test", testData)
+}

--- a/options.go
+++ b/options.go
@@ -16,6 +16,9 @@ type Options struct {
 	IgnoreFields  []string                           // Specific JSON fields to ignore
 	CustomCompare func(expected, actual []byte) bool // Custom comparison function
 
+	// Path settings
+	BaseDir string // Base directory for golden files (default: "testdata")
+
 	// Internal settings
 	contextLines int       // Lines of context in diff
 	bufferSize   int       // Buffer size for file operations
@@ -53,6 +56,14 @@ func WithIgnoreOrder(ignore bool) Option {
 func WithCustomCompare(fn func(expected, actual []byte) bool) Option {
 	return func(o *Options) {
 		o.CustomCompare = fn
+	}
+}
+
+// WithBaseDir sets a custom base directory for golden files.
+// Default is "testdata".
+func WithBaseDir(dir string) Option {
+	return func(o *Options) {
+		o.BaseDir = dir
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `WithBaseDir` option to customize the base directory for golden files
- Default behavior unchanged (uses `"testdata"`)
- Add test for `WithBaseDir` option

## Usage
```go
g := golden.New(t, golden.WithUpdate(true), golden.WithBaseDir("custom/path"))
g.Assert("test", data)
// Golden file will be created at: custom/path/test_TestXxx_test.golden.go
```

## Test plan
- [x] Added `TestGoldenWithBaseDir` test
- [x] All existing tests pass